### PR TITLE
Version from cargo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -588,7 +588,7 @@ checksum = "3a3076410a55c90011c298b04d0cfa770b00fa04e1e3c97d3f6c9de105a03844"
 
 [[package]]
 name = "fix_local_mail"
-version = "1.5.0"
+version = "1.6.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "fix_local_mail"
-version = "1.5.0"
+authors = ["C. Pospiech <pospiech-HD@t-online.de>"]
+version = "1.6.0"
 edition = "2021"
 license = "Apache-2.0"
 

--- a/src/cmdline.rs
+++ b/src/cmdline.rs
@@ -15,7 +15,7 @@
 use clap::Parser;
 
 #[derive(Parser, Debug, Default)]
-#[command(name = "fix_local_mail", author = "C. Pospiech", version = "1.3", about = "fix local mail folders", long_about = None)]
+#[command(name = env!("CARGO_PKG_NAME"), author = env!("CARGO_PKG_AUTHORS"), version = env!("CARGO_PKG_VERSION"), about = "fix local mail folders", long_about = None)]
 pub struct CliArgs {
     /// Perform a dry run without making actual changes
     #[arg(short = 'D', long, default_value_t = false)]


### PR DESCRIPTION
This is pulling the version number for clap from Cargo.toml.